### PR TITLE
feat: optional prefetching of files (e.g. from s3)

### DIFF
--- a/tap_spreadsheets_anywhere/configuration.py
+++ b/tap_spreadsheets_anywhere/configuration.py
@@ -33,6 +33,7 @@ CONFIG_CONTRACT = Schema({
         Optional('split_edifact_column'): str,
         Optional('edifact_message_batch_size'): int,
         Optional('edifact_max_size'): int,
+        Optional('num_files_to_prefetch'): int,
         Optional('schema_overrides'): {
             str: {
                 Required('type'): Any(Any('null','string','integer','number','date-time','object'),


### PR DESCRIPTION
Use multithreading to enable parallel s3 downloads in order to avoid io bottleneck with large number of small files to be processed